### PR TITLE
Dependencies issue

### DIFF
--- a/MD-IFP.yml
+++ b/MD-IFP.yml
@@ -79,7 +79,7 @@ dependencies:
     - kiwisolver==1.1.0
     - matplotlib==3.1.2
     - mdanalysis==0.20.1
-    - mdtraj==1.9.3
+    - --no-binary mdtraj==1.9.3
     - mmtf-python==1.1.2
     - mock==3.0.5
     - msgpack==0.6.2
@@ -90,5 +90,6 @@ dependencies:
     - seaborn==0.10.0
     - six==1.13.0
     - wget==3.2
+    - sklearn
 prefix: /exports/scratch/kokhda/anaconda/envs/JN
 

--- a/MD-IFP.yml
+++ b/MD-IFP.yml
@@ -91,5 +91,6 @@ dependencies:
     - six==1.13.0
     - wget==3.2
     - sklearn
+    - nglview
 prefix: /exports/scratch/kokhda/anaconda/envs/JN
 


### PR DESCRIPTION
Due to an issue in the env. set up with **conda env create -f MD-IFP.yml** command, I would suggest to modify the MD-IFP.yml as follow:

- The package mdtraj installed with no **--no-binary** option gives a PEP 517 error.

-  sklearn and nglview should be included.

Thank you!